### PR TITLE
Add React and Flask frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
-# Minecraft Mod Auto-Updater
+# Minecraft Mod Updater
 
-Continuous-integration workflow that:
-1. Checks Modrinth and CurseForge to see if a build for the requested Minecraft version already exists.
-2. If none is found, rebuilds the mod JAR, rewrites its metadata to the target version, and uploads the rebuilt JAR as a workflow artifact.
+This project provides tools for retargeting Minecraft mod JARs to a different
+game version. You can use either the simple Tkinter GUI or a web interface
+served with Flask and React.
 
 ## Usage
-* Manually trigger the workflow from the “Actions” tab and supply **target_version** (e.g. `1.20.4`).
-* Or let the nightly cron run do its thing.
-* Grab the rebuilt JAR from the workflow run’s “Artifacts” section.
+1. Run `python3 mod_updater_gui.py`.
+2. Select the JAR file you want to update.
+3. Enter the target Minecraft version along with your Modrinth project ID, CurseForge mod ID and API key.
+4. The tool checks both sites for an existing build and, if none is found, writes a new JAR next to the original named `modname}{version.jar`.
 
-### Required secrets
-| Name                | Purpose                          |
-| ------------------- | -------------------------------- |
-| `CURSEFORGE_API_KEY`| Access to CurseForge API         |
+The Tkinter app relies on the `requests` package which is generally available
+with Python 3. If missing, install it with `pip install requests`.
 
-### Required repository variables
-| Name                   | Example            |
-| ---------------------- | ------------------ |
-| `MODRINTH_PROJECT_ID`  | `abcd1234`         |
-| `CURSEFORGE_MOD_ID`    | `123456`           |
-
-No external publishing happens here—just build and ship the JAR artifact.
+## React Web Interface
+1. Install the server dependencies with `pip install flask requests`.
+2. Run `python3 server.py`.
+3. Visit [http://localhost:5000](http://localhost:5000) to access the React
+   frontend and update your JAR.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <title>Minecraft Mod Updater</title>
+</head>
+<body>
+<div id="root"></div>
+<script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+<script type="text/babel">
+function App() {
+  const [jar, setJar] = React.useState(null);
+  const [version, setVersion] = React.useState('');
+  const [modrinthId, setModrinthId] = React.useState('');
+  const [curseId, setCurseId] = React.useState('');
+  const [curseKey, setCurseKey] = React.useState('');
+  const [msg, setMsg] = React.useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!jar) return;
+    const fd = new FormData();
+    fd.append('jar', jar);
+    fd.append('version', version);
+    fd.append('modrinth_id', modrinthId);
+    fd.append('curse_id', curseId);
+    fd.append('curse_key', curseKey);
+    fetch('/update', {method: 'POST', body: fd}).then(async res => {
+      if (res.headers.get('content-type')?.includes('application/json')) {
+        const j = await res.json();
+        setMsg(j.status === 'exists' ? 'Target version already exists.' : 'Unknown response');
+      } else if (res.ok) {
+        const blob = await res.blob();
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = '';
+        a.click();
+        window.URL.revokeObjectURL(url);
+        setMsg('Download started.');
+      } else {
+        setMsg('Error: ' + res.statusText);
+      }
+    }).catch(err => setMsg('Error: ' + err));
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>Jar file: <input type="file" accept=".jar" onChange={e => setJar(e.target.files[0])} /></label>
+      </div>
+      <div>
+        <label>Target version: <input value={version} onChange={e => setVersion(e.target.value)} /></label>
+      </div>
+      <div>
+        <label>Modrinth Project ID: <input value={modrinthId} onChange={e => setModrinthId(e.target.value)} /></label>
+      </div>
+      <div>
+        <label>CurseForge Mod ID: <input value={curseId} onChange={e => setCurseId(e.target.value)} /></label>
+      </div>
+      <div>
+        <label>CurseForge API Key: <input value={curseKey} onChange={e => setCurseKey(e.target.value)} /></label>
+      </div>
+      <button type="submit">Update</button>
+      <p>{msg}</p>
+    </form>
+  );
+}
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>

--- a/mod_updater.py
+++ b/mod_updater.py
@@ -1,0 +1,63 @@
+import json
+import os
+import tempfile
+import zipfile
+import requests
+
+
+def version_exists(modrinth_id, curse_id, version, curse_key):
+    """Return True if a build for the given version exists on Modrinth or CurseForge."""
+    api = f"https://api.modrinth.com/v2/project/{modrinth_id}/version?loaders=fabric&game_versions={version}"
+    try:
+        r = requests.get(api, timeout=10)
+        if r.ok and r.json() != []:
+            return True
+    except Exception:
+        pass
+
+    api = f"https://api.curseforge.com/v1/mods/{curse_id}/files?gameVersion={version}"
+    headers = {"x-api-key": curse_key}
+    try:
+        r = requests.get(api, headers=headers, timeout=10)
+        if r.ok and r.json().get('data'):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def update_jar(jar_path, version):
+    """Retarget the given JAR to the specified Minecraft version and return the path to the new file."""
+    mod_name = os.path.splitext(os.path.basename(jar_path))[0]
+    out_name = mod_name + '}{' + version + '.jar'
+    with tempfile.TemporaryDirectory() as tmp:
+        with zipfile.ZipFile(jar_path, 'r') as jar:
+            jar.extractall(tmp)
+
+        mods_toml = os.path.join(tmp, 'META-INF', 'mods.toml')
+        if os.path.isfile(mods_toml):
+            data = []
+            with open(mods_toml, 'r') as f:
+                for line in f:
+                    if line.strip().startswith('mcversion'):
+                        data.append(f'    mcversion = "{version}"\n')
+                    else:
+                        data.append(line)
+            with open(mods_toml, 'w') as f:
+                f.writelines(data)
+
+        fabric_json = os.path.join(tmp, 'fabric.mod.json')
+        if os.path.isfile(fabric_json):
+            with open(fabric_json, 'r') as f:
+                j = json.load(f)
+            j.setdefault('depends', {})['minecraft'] = version
+            with open(fabric_json, 'w') as f:
+                json.dump(j, f, indent=2)
+
+        out_path = os.path.join(os.path.dirname(jar_path), out_name)
+        with zipfile.ZipFile(out_path, 'w', zipfile.ZIP_DEFLATED) as out:
+            for root, _, files in os.walk(tmp):
+                for fn in files:
+                    fp = os.path.join(root, fn)
+                    out.write(fp, os.path.relpath(fp, tmp))
+    return out_path

--- a/mod_updater_gui.py
+++ b/mod_updater_gui.py
@@ -1,0 +1,70 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+from mod_updater import version_exists, update_jar
+
+
+class ModUpdaterApp:
+    def __init__(self, master):
+        self.master = master
+        master.title("Minecraft Mod Updater")
+
+        tk.Label(master, text="Jar file:").grid(row=0, column=0, sticky="e")
+        self.jar_path_var = tk.StringVar()
+        tk.Entry(master, textvariable=self.jar_path_var, width=40).grid(row=0, column=1)
+        tk.Button(master, text="Browse", command=self.choose_jar).grid(row=0, column=2)
+
+        tk.Label(master, text="Target version:").grid(row=1, column=0, sticky="e")
+        self.version_var = tk.StringVar()
+        tk.Entry(master, textvariable=self.version_var).grid(row=1, column=1, sticky="we")
+
+        tk.Label(master, text="Modrinth Project ID:").grid(row=2, column=0, sticky="e")
+        self.modrinth_var = tk.StringVar()
+        tk.Entry(master, textvariable=self.modrinth_var).grid(row=2, column=1, sticky="we")
+
+        tk.Label(master, text="CurseForge Mod ID:").grid(row=3, column=0, sticky="e")
+        self.curse_var = tk.StringVar()
+        tk.Entry(master, textvariable=self.curse_var).grid(row=3, column=1, sticky="we")
+
+        tk.Label(master, text="CurseForge API Key:").grid(row=4, column=0, sticky="e")
+        self.curse_key_var = tk.StringVar()
+        tk.Entry(master, textvariable=self.curse_key_var, show='*').grid(row=4, column=1, sticky="we")
+
+        tk.Button(master, text="Update", command=self.run_update).grid(row=5, column=0, columnspan=3, pady=5)
+
+    def choose_jar(self):
+        path = filedialog.askopenfilename(filetypes=[("JAR files", "*.jar")])
+        if path:
+            self.jar_path_var.set(path)
+
+    def run_update(self):
+        jar_path = self.jar_path_var.get()
+        target_version = self.version_var.get().strip()
+        modrinth_id = self.modrinth_var.get().strip()
+        curse_id = self.curse_var.get().strip()
+        curse_key = self.curse_key_var.get().strip()
+
+        if not (jar_path and target_version and modrinth_id and curse_id):
+            messagebox.showerror("Missing info", "Please fill out all fields")
+            return
+
+        if version_exists(modrinth_id, curse_id, target_version, curse_key):
+            messagebox.showinfo("Exists", "Target version already published")
+            return
+
+        try:
+            out_path = update_jar(jar_path, target_version)
+            messagebox.showinfo("Success", f"Updated jar saved to {out_path}")
+        except Exception as exc:
+            messagebox.showerror("Error", str(exc))
+
+
+
+def main():
+    root = tk.Tk()
+    app = ModUpdaterApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/server.py
+++ b/server.py
@@ -1,0 +1,37 @@
+from flask import Flask, request, send_from_directory, jsonify
+import os
+
+from mod_updater import version_exists, update_jar
+
+app = Flask(__name__, static_folder='frontend', static_url_path='')
+
+
+@app.route('/')
+def index():
+    return app.send_static_file('index.html')
+
+
+@app.route('/update', methods=['POST'])
+def update():
+    jar = request.files.get('jar')
+    target_version = request.form.get('version', '').strip()
+    modrinth_id = request.form.get('modrinth_id', '').strip()
+    curse_id = request.form.get('curse_id', '').strip()
+    curse_key = request.form.get('curse_key', '').strip()
+
+    if not all([jar, target_version, modrinth_id, curse_id]):
+        return 'Missing parameters', 400
+
+    os.makedirs('uploads', exist_ok=True)
+    tmp_path = os.path.join('uploads', jar.filename)
+    jar.save(tmp_path)
+
+    if version_exists(modrinth_id, curse_id, target_version, curse_key):
+        return jsonify({'status': 'exists'})
+
+    out_path = update_jar(tmp_path, target_version)
+    return send_from_directory(os.path.dirname(out_path), os.path.basename(out_path), as_attachment=True)
+
+
+if __name__ == '__main__':
+    app.run(port=5000, debug=True)


### PR DESCRIPTION
## Summary
- refactor update logic into a reusable `mod_updater` module
- update Tkinter GUI to use the shared functions
- add a Flask server exposing an `/update` API
- provide a simple React UI served from `frontend/`
- document the web interface in the README

## Testing
- `python3 -m py_compile mod_updater.py mod_updater_gui.py server.py`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862cc5fdbac8333af870f389714451b